### PR TITLE
Stop  numeric strings being handled as numbers

### DIFF
--- a/i2c/26-i2c.js
+++ b/i2c/26-i2c.js
@@ -149,14 +149,14 @@ module.exports = function(RED) {
                 } else {
                     myPayload = RED.util.evaluateNodeProperty(this.payload, this.payloadType, this,msg);
                 }
-                if (myPayload == null || node.count == 0) {
+                if (myPayload == null || (node.count == 0 && !typeof myPayload === 'string')) {
                     node.port.sendByte(address, command,  function(err) {
                         if (err) { node.error(err, msg);
                         } else {
                             node.send(msg);
                         }
                     });
-                } else if (!isNaN(myPayload) && !(typeof myPayload === 'string')) {
+                } else if (!isNaN(myPayload) && !typeof myPayload === 'string') {
                     var data = myPayload;
                     myPayload = Buffer.allocUnsafe(node.count);
                     myPayload.writeIntLE(data, 0, node.count, true);

--- a/i2c/26-i2c.js
+++ b/i2c/26-i2c.js
@@ -156,7 +156,7 @@ module.exports = function(RED) {
                             node.send(msg);
                         }
                     });
-                } else if (!isNaN(myPayload)) {
+                } else if (!isNaN(myPayload) && !(typeof myPayload === 'string')) {
                     var data = myPayload;
                     myPayload = Buffer.allocUnsafe(node.count);
                     myPayload.writeIntLE(data, 0, node.count, true);


### PR DESCRIPTION
Passing a numeric string to the i2c-out node causes an obscure error message to be emitted. The problem arises in the use of isNaN to determine what is in the message payload. Any string object that can be implicitly converted into a number object will treated as though it is a number object.  This is not a desirable  behaviour and causes errors later on in the code. This patch addresses that issue.
It also partially addresses the issue that the byte count from the node config should be optional for a payload object that has an implicit length within it. Examples are strings and buffers. The documentation implies that the count field is only used for numbers. But this is not true. As far as I can see the only object type that entirely ignores the byte count is string. This fix still needs the user to supply a count of zero to get past the validation checks when using a string. A more robust approach would require a much larger change to the code. I will leave this to younger and more agile brains than mine. I would suggest that for types that do not require the use of a count then the field should be optional but if supplied should be used to truncate what is sent.